### PR TITLE
build: :bug: fix port undefined into telegram constructor

### DIFF
--- a/packages/telegram/src/provider.ts
+++ b/packages/telegram/src/provider.ts
@@ -126,8 +126,8 @@ class TelegramProvider extends ProviderClass {
     this.vendor.telegram.sendAudio(chatId, media, { caption })
   }
 
-  initHttpServer(port: number) {
-    this.http = new TelegramHttpServer(this.globalVendorArgs.port || 9000)
+  initHttpServer(port?: number) {
+    this.http = new TelegramHttpServer(port || this.globalVendorArgs?.port || 9000)
 
     const methods: BotCtxMiddleware = {
       sendMessage: this.sendMessage,


### PR DESCRIPTION
fix Error when assing a http server into telegram provider

Error: Port is undefined

use case:
the constructor no had  port